### PR TITLE
Update contract.js

### DIFF
--- a/src/hooks/contract.js
+++ b/src/hooks/contract.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import Big from "big.js";
 
 const BOATLOAD_OF_GAS = Big(1)
-  .times(10 ** 16)
+  .times(10 ** 14)
   .toFixed();
 
 const initialState = {


### PR DESCRIPTION
10^16 triggers gasExceededError when createCorgi is called on testnet.  10^14 seems to work.